### PR TITLE
Adds auto mode switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ For humidifier devices, a humidifier is also exposes to HomeKit with support for
 
 Optionally, the following switches are exposed:
 - Night mode (on/off)
+- Auto mode (on/off)
 - Jet Focus (on/off; DP01, TP02, HP02, BP02, BP03, BP04 and BP06 are not supported)
 - Continuous Monitoring (on/off)
 
@@ -160,6 +161,8 @@ This method seems to work for most people, see [#196](https://github.com/lukasro
 **enableNightModeWhenActivating**: If set to `true`, night mode is enabled when you activate the device. Defaults to `false`.
 
 **isNightModeEnabled**: If set to `true`, a switch is exposed for the night mode. Defaults to `false`.
+
+**isAutoModeEnabled**: If set to `true`, a switch is exposed for the auto mode. Defaults to `false`.
 
 **isJetFocusEnabled**: If set to `true`, a switch is exposed for the jet focus. DP01, TP02 and HP02 are not supported. Defaults to `false`.
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -67,6 +67,13 @@
                             "required": true,
                             "description": "If set to true, a switch is exposed for the night mode."
                         },
+                        "isAutoModeEnabled": {
+                            "title": "Expose Auto Mode",
+                            "type": "boolean",
+                            "default": false,
+                            "required": true,
+                            "description": "If set to true, a switch is exposed for the auto mode."
+                        },
                         "isJetFocusEnabled": {
                             "title": "Expose Jet Focus",
                             "type": "boolean",


### PR DESCRIPTION
Implemented exactly like the night mode switch, the auto mode switch allows toggling auto mode without changing any other settings.

My use case is that I like to run the fan at high speed at night and then switch it to auto-mode during the day. Currently, I'm not able to automate the transition into auto-mode because setting the characteristics with a scene also sets the fan speed. With the auto mode switch, I'll be able to just toggle auto mode to on in my morning automation.